### PR TITLE
V1.3.1 dev

### DIFF
--- a/lib/topology_builder/bgp_proc_data_builder.rb
+++ b/lib/topology_builder/bgp_proc_data_builder.rb
@@ -249,13 +249,19 @@ module NetomoxExp
       end
       # rubocop:disable Metrics/AbcSize
 
+      # @param [BgpProcessConfigurationTableRecord] proc_rec A record of BGP process configuration
+      # @return [String] Name of layer3 (underlay) node name
+      def l3_node_name(proc_rec)
+        proc_rec.grt? ? proc_rec.node : "#{proc_rec.node}_#{proc_rec.vrf}"
+      end
+
       # @param [BgpProcessConfigurationTableRecord] proc_rec BGP process configuration
       # return [void]
       def add_bgp_node_tp(proc_rec)
         debug_print "# node: #{proc_rec.node} (vrf=#{proc_rec.vrf}), router_id=#{proc_rec.router_id}"
         bgp_node = @network.node(proc_rec.router_id)
         bgp_node.attribute = bgp_node_attribute(proc_rec)
-        bgp_node.supports.push([@layer3p.name, proc_rec.node])
+        bgp_node.supports.push([@layer3p.name, l3_node_name(proc_rec)])
 
         # supporting node (NOTICE: vrf is not assumed)
         peer_recs = @bgp_peer_conf.find_all_recs_by_node_vrf(proc_rec.node, proc_rec.vrf)

--- a/lib/topology_builder/bgp_proc_data_builder.rb
+++ b/lib/topology_builder/bgp_proc_data_builder.rb
@@ -10,7 +10,7 @@ module NetomoxExp
     # rubocop:disable Metrics/ClassLength
 
     # BGP data builder
-    class BgpDataBuilder < DataBuilderBase
+    class BgpProcDataBuilder < DataBuilderBase
       # @param [String] target Target network (config) data name
       # @param [Netomox::PseudoDSL::PNetwork] layer3p Layer3 network topology
       def initialize(target:, layer3p:, debug: false)
@@ -89,14 +89,15 @@ module NetomoxExp
 
         l3_local_node_name = bgp_local_node.supports[0][1]
         l3_local_tp = find_l3_tp_by_ip(l3_local_node_name, remote_ip)
-        l3_local_ip = find_ip_in_l3_tp_includes(l3_local_tp, remote_ip)
-        if l3_local_ip.nil?
+        if l3_local_tp.nil?
           # NOTE: bgp-multihop or faulty L3 attribute case
-          @logger.warn "underlay L3 tp of #{l3_local_node_name}[#{l3_local_tp.name}] does not have IP or bgp-multihop?"
+          @logger.warn "underlay L3 of #{bgp_local_node.name}, #{l3_local_node_name} does not have remote-linked tp " \
+                       "or peer #{remote_ip} is bgp-multihop?"
           return ''
         end
 
-        debug_print "#     -> l3_local_tp: #{l3_local_node_name}[#{l3_local_tp.name}] : l3_local_ip: #{l3_local_ip}"
+        l3_local_ip = find_ip_in_l3_tp_includes(l3_local_tp, remote_ip)
+        debug_print "#     -> l3_local_tp: #{l3_local_node_name} : l3_local_ip: #{l3_local_ip}"
         ip_string_without_prefix(l3_local_ip)
       end
       # rubocop:enable Metrics/MethodLength
@@ -203,7 +204,7 @@ module NetomoxExp
 
       # @param [String] l3_node_name L3 node name to support
       # @param [String] ip_addr IP address
-      # @return [Netomox::PseudoDSL::PTermPoint] L3 term-point to support the bgp term-point
+      # @return [Netomox::PseudoDSL::PTermPoint,nil] L3 term-point to support the bgp term-point
       # @raise [StandardError]
       def find_l3_tp_by_ip(l3_node_name, ip_addr)
         l3_node = @layer3p.node(l3_node_name)

--- a/lib/topology_builder/csv_mapper/bgp_proc_conf_table.rb
+++ b/lib/topology_builder/csv_mapper/bgp_proc_conf_table.rb
@@ -53,6 +53,11 @@ module NetomoxExp
           @tie_breaker = record[:tie_breaker]
         end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+        # @return [Boolean] true if GRT ip info (not VRF instance)
+        def grt?
+          @vrf == 'default'
+        end
       end
 
       # bgp process configuration table

--- a/lib/topology_builder/csv_mapper/interface_prop_table.rb
+++ b/lib/topology_builder/csv_mapper/interface_prop_table.rb
@@ -117,7 +117,7 @@ module NetomoxExp
         # Unit interface number (for junos interface)
         # @return [nil, String] unit number string
         def unit_number
-          %r{[-/\w]+\d+(?::\d+)?\.(\d+)}.match(interface).to_a[1]
+          JUNOS_INTERFACE_REGEXP.match(interface).to_a[2]
         end
 
         # @return [String]

--- a/lib/topology_builder/csv_mapper/interface_prop_table.rb
+++ b/lib/topology_builder/csv_mapper/interface_prop_table.rb
@@ -184,7 +184,7 @@ module NetomoxExp
         # @return [Array<InterfacePropertiesTableRecord>] Found records
         def find_all_unit_records_by_node_intf(node_name, intf_name)
           @records.find_all do |rec|
-            rec.node == node_name && rec.interface =~ /#{intf_name}.\d+/
+            rec.node == node_name && rec.interface =~ /#{intf_name}\.\d+/
           end
         end
       end

--- a/lib/topology_builder/csv_mapper/ip_owners_table.rb
+++ b/lib/topology_builder/csv_mapper/ip_owners_table.rb
@@ -47,6 +47,11 @@ module NetomoxExp
         def to_s
           [@node, @vrf, @interface, @ip, @mask].map(&:to_s).join(', ')
         end
+
+        # @return [Boolean] true if GRT ip info (not VRF instance)
+        def grt?
+          @vrf == 'default'
+        end
       end
 
       # ip-owners table

--- a/lib/topology_builder/csv_mapper/ip_owners_table.rb
+++ b/lib/topology_builder/csv_mapper/ip_owners_table.rb
@@ -37,6 +37,12 @@ module NetomoxExp
           LO_INTERFACE_REGEXP.match?(@interface)
         end
 
+        # @return [String] Physical (without unit number) interface name
+        def physical_interface
+          match = JUNOS_INTERFACE_REGEXP.match(@interface)
+          match ? match.to_a[1] : @interface
+        end
+
         # @return [String]
         def to_s
           [@node, @vrf, @interface, @ip, @mask].map(&:to_s).join(', ')

--- a/lib/topology_builder/l1_data_builder.rb
+++ b/lib/topology_builder/l1_data_builder.rb
@@ -7,8 +7,6 @@ require_relative 'csv_mapper/node_props_table'
 
 module NetomoxExp
   module TopologyBuilder
-    # rubocop:disable Metrics/ClassLength
-
     # L1 data builder
     class L1DataBuilder < DataBuilderBase
       # @param [String] target Target network (config) data name
@@ -171,6 +169,5 @@ module NetomoxExp
         end
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/topology_builder/l1_l3_data_builder.rb
+++ b/lib/topology_builder/l1_l3_data_builder.rb
@@ -36,7 +36,7 @@ module NetomoxExp
       # @return [String] physical interface name for junos (nothing to do for other OS)
       def select_physical_tp_name(l1_node, rec)
         # e.g. xe-0/3/0:0.0, ge-0/0/1.0
-        juniper_node?(l1_node) ? rec.interface.gsub(/(\d+(?::\d+)?)\.\d+/, '\1') : rec.interface
+        juniper_node?(l1_node) ? rec.physical_interface : rec.interface
       end
 
       # @param [Netomox::PseudoDSL::PNode] l1_node Layer1 node

--- a/lib/topology_builder/l1_l3_data_builder.rb
+++ b/lib/topology_builder/l1_l3_data_builder.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative 'l1_data_builder'
+require_relative 'csv_mapper/ip_owners_table'
+
+module NetomoxExp
+  module TopologyBuilder
+    # Extended L1 data builder
+    #   Add unlinked but ip-owner interfaces ()term-points) into Layer1.
+    class L1L3DataBuilder < L1DataBuilder
+      # @param [String] target Target network (config) data name
+      def initialize(target:, debug: false)
+        super(target:, debug:)
+
+        @ip_owners = CSVMapper::IPOwnersTable.new(target)
+      end
+
+      # @return [Netomox::PseudoDSL::PNetworks] Networks contains only layer1 network topology
+      def make_networks
+        super()
+
+        add_unlinked_ip_owner_tp
+        @networks
+      end
+
+      private
+
+      # @param [Netomox::PseudoDSL::PNode] l1_node Layer1 node
+      # @return [Boolean] True if the node os-type is juniper
+      def juniper_node?(l1_node)
+        l1_node.attribute[:os_type].downcase == 'juniper'
+      end
+
+      # @param [Netomox::PseudoDSL::PNode] l1_node Layer1 node
+      # @param [CSVMapper::IPOwnersTableRecord] rec A record of ip_owners table
+      # @return [String] physical interface name for junos (nothing to do for other OS)
+      def select_physical_tp_name(l1_node, rec)
+        # e.g. xe-0/3/0:0.0, ge-0/0/1.0
+        juniper_node?(l1_node) ? rec.interface.gsub(/(\d+(?::\d+)?)\.\d+/, '\1') : rec.interface
+      end
+
+      # @param [Netomox::PseudoDSL::PNode] l1_node Layer1 node
+      # @param [NetomoxExp::CSVMapper::IPOwnersTableRecord] rec A record of ip-owner table
+      # @return [Array<String>] Member interface names
+      def find_all_lag_member_interfaces(l1_node, rec)
+        # if ip-owner interface is junos unit interface, convert to physical interface name
+        l1_tp_name = select_physical_tp_name(l1_node, rec)
+        intf_prop_rec = @intf_props.find_record_by_node_intf(l1_node.name, l1_tp_name)
+
+        # not found
+        if intf_prop_rec.nil?
+          @logger.error("#{l1_node.name}[#{l1_tp_name}] is not found in interface-prop table")
+          return []
+        end
+
+        # return itself as member-interface to add Layer1 if the interface is not LAG
+        return [l1_tp_name] unless intf_prop_rec.lag_parent?
+
+        intf_prop_rec.lag_member_interfaces
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+
+      # add unlinked interface which owns ip address (interface to external network/AS)
+      # @return [void]
+      def add_unlinked_ip_owner_tp
+        debug_print '# add_unlinked_ip_owner_tp'
+        @network.nodes.each do |l1_node|
+          debug_print "  - target node: #{l1_node.name}"
+          @ip_owners.find_all_records_by_node(l1_node.name).each do |rec|
+            l1_link = @network.find_link_by_src_name(l1_node.name, rec.interface)
+            # nothing to do if the term-point is linked (L1) or logical interface
+            next if l1_link || rec.loopback_interface?
+
+            debug_print "    - find unlinked tp: #{rec.interface}"
+            # if aggregated interface (LAG), add its children
+            find_all_lag_member_interfaces(l1_node, rec).each do |member_tp_name|
+              debug_print "    - add unlinked tp: #{rec.interface}"
+              add_node_tp(l1_node.name, member_tp_name)
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    end
+  end
+end

--- a/lib/topology_builder/l2_data_checker.rb
+++ b/lib/topology_builder/l2_data_checker.rb
@@ -17,7 +17,7 @@ module NetomoxExp
 
       protected
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
 
       # @param [Netomox::PseudoDSL::PNode] src_node Source layer1 node
       # @param [InterfacePropertiesTableRecord] src_tp_prop Term-point properties of source
@@ -27,6 +27,8 @@ module NetomoxExp
       def port_l2_config_check(src_node, src_tp_prop, dst_node, dst_tp_prop)
         target_src_tp_prop = choose_tp_prop(src_node, src_tp_prop)
         target_dst_tp_prop = choose_tp_prop(dst_node, dst_tp_prop)
+        debug_print "  - src_tp_prop: #{target_src_tp_prop}"
+        debug_print "  - dst_tp_prop: #{target_dst_tp_prop}"
         if target_src_tp_prop.nil? || target_dst_tp_prop.nil?
           return {
             type: :error,
@@ -53,7 +55,7 @@ module NetomoxExp
           }
         end
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       private
 

--- a/lib/topology_builder/l2_data_checker.rb
+++ b/lib/topology_builder/l2_data_checker.rb
@@ -62,7 +62,7 @@ module NetomoxExp
       # @param [Array<InterfacePropertiesTableRecord>] unit_props Unit interface properties of phy_intf
       # @return [InterfacePropertiesTableRecord] Phy. interface property (as trunk port)
       def change_property_as_trunk(phy_prop, unit_props)
-        debug_print "    unit_props: #{unit_props}"
+        debug_print "    unit_props: #{unit_props.map(&:to_s)}"
         # NOTICE: L3 sub-interface : use encapsulation_vlan as vlan-id of the unit-interface
         phy_prop.allowed_vlans = unit_props.map(&:encapsulation_vlan)
         debug_print "    junos trunk port subif: phy:#{phy_prop}, allowed_vlans:#{phy_prop.allowed_vlans}"

--- a/lib/topology_builder/l3_data_builder.rb
+++ b/lib/topology_builder/l3_data_builder.rb
@@ -48,7 +48,7 @@ module NetomoxExp
       # @param [IPOwnersTableRecord] rec A record of IP-Owners table
       # @return [String] Name of layer3 node
       def l3_node_name(rec)
-        rec.vrf == 'default' ? rec.node : "#{rec.node}_#{rec.vrf}"
+        rec.grt? ? rec.node : "#{rec.node}_#{rec.vrf}"
       end
 
       # @param [IPOwnersTableRecord] rec A record of IP-Owners table
@@ -61,6 +61,7 @@ module NetomoxExp
         l3_node.attribute = {
           node_type: node_name =~ /.*svr\d+/i ? 'endpoint' : 'node' # TODO: ad-hoc node type detection...
         }
+        l3_node.attribute[:flags] = ["vrf:#{rec.vrf}"] unless rec.grt?
         l3_node
       end
 
@@ -150,7 +151,8 @@ module NetomoxExp
 
         if !linked_l2_tp?(l2_node, l2_tp) && rec.nil?
           # raise error for unlinked tp
-          raise StandardError, "Corresponding ip-owner interface is not found: #{l2_node.name}[#{l2_tp.name}]"
+          @logger.error "Corresponding ip-owner interface is not found: #{l2_node.name}[#{l2_tp.name}]"
+          return [nil, nil]
         end
 
         l3_node = add_l3_node(rec, l2_node)

--- a/lib/topology_builder/l3_data_builder.rb
+++ b/lib/topology_builder/l3_data_builder.rb
@@ -59,7 +59,7 @@ module NetomoxExp
         l3_node = @network.node(node_name)
         l3_node.supports.push([@layer2p.name, l2_node.name])
         l3_node.attribute = {
-          node_type: node_name =~ /.*svr\d+/i ? 'endpoint' : 'node'
+          node_type: node_name =~ /.*svr\d+/i ? 'endpoint' : 'node' # TODO: ad-hoc node type detection...
         }
         l3_node
       end
@@ -80,18 +80,50 @@ module NetomoxExp
         l3_tp
       end
 
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+
       # @param [Netomox::PseudoDSL::PNode] l2_node Layer2 node
       # @param [String] l2_tp_name Node name in the l2_node
       # @return [Array(CSVMapper::IPOwnersTableRecord, Netomox::PseudoDSL::PNode)]
       #   L3 (IPOwners) record and corresponding L2 node
+      #   NOTE: it will return nil as IPOwnersTableRecord if ip-owner record is not found
       def ip_rec_by_l2_node(l2_node, l2_tp_name)
-        rec = @ip_owners.find_record_by_node_intf(l2_node.attribute[:name], l2_tp_name)
-        # if rec not found, search virtual node (GRT/VRF)
-        rec ||= @ip_owners.find_vlan_intf_record_by_node(l2_node.attribute[:name], l2_node.attribute[:vlan_id])
-        # debug_print "  l2_edge=#{l2_edge}, rec=#{rec}"
+        # aliases
+        l1_node_name = l2_node.attribute[:name]
+        l2_vid = l2_node.attribute[:vlan_id]
 
-        [rec, l2_node]
+        # if "l1_node_name[l2_tp_name]" interface has ip address
+        debug_print "    ip_rec_by_l2_node, #{l2_node.name}, vid#{l2_vid} -> #{l1_node_name}, #{l2_tp_name}"
+        ip_owner_rec = @ip_owners.find_record_by_node_intf(l1_node_name, l2_tp_name)
+
+        # if rec not found, search virtual node (GRT/VRF)
+        ip_owner_rec ||= @ip_owners.find_vlan_intf_record_by_node(l1_node_name, l2_vid)
+
+        # if rec not found, search LAG parent
+        intf_prop_rec = @intf_props.find_record_by_node_intf(l1_node_name, l2_tp_name)
+        if intf_prop_rec&.lag_member?
+          lag_parent_name = intf_prop_rec.lag_parent_interface
+          debug_print "    LAG member: parent=#{l1_node_name}[#{lag_parent_name}]"
+          # if parent has ip
+          # - cisco, PoX
+          # - junos, aeX (without unit number)
+          ip_owner_rec ||= @ip_owners.find_record_by_node_intf(l1_node_name, lag_parent_name)
+          # if (the node is junos and) unit interface has ip
+          # NOTE:
+          # in interface-props table
+          #   (junos node)[aeX]     <parent> -> LAG members: [ge-X/Y,...]
+          #   (junos node)[ge-X/Y]  <member> -> LAG group: [aeX]
+          # in ip-owners table
+          #   (junos node)[aeX.P] ... unit number is independent with LAG
+          #   currently, .0 or vlan-id is used as unit number...but that is local naming policy
+          ip_owner_rec ||= @ip_owners.find_record_by_node_intf(l1_node_name, "#{lag_parent_name}.#{l2_vid}")
+          ip_owner_rec ||= @ip_owners.find_record_by_node_intf(l1_node_name, "#{lag_parent_name}.0")
+        end
+
+        debug_print "    ip_rec_by_node rec=#{ip_owner_rec}"
+        [ip_owner_rec, l2_node]
       end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       # @param [Netomox::PseudoDSL::PLinkEdge] l2_edge Layer2 link edge
       # @return [Array(CSVMapper::IPOwnersTableRecord, Netomox::PseudoDSL::PNode)]
@@ -101,19 +133,31 @@ module NetomoxExp
         ip_rec_by_l2_node(l2_node, l2_edge.tp)
       end
 
+      # rubocop:disable Metrics/AbcSize
+
       # @param [Netomox::PseudoDSL::PNode] l2_node Layer2 node
       # @param [Netomox::PseudoDSL::PTermPoint] l2_tp Layer2 term-point
       # @return [Array(Netomox::PseudoDSL::PNode, Netomox::PseudoDSL::PTermPoint)] Added L3-Node and term-point pair
+      # @raise StandardError if corresponding ip-owner term-point is not found for the unlinked-tp.
+      #   Because in L1, topology-builder insert term-points that is not linked but owns ip-address.
+      #   So, in L3, it must be found corresponding ip-owner tp info of unlinked term-point.
       def add_l3_node_tp_by_l2_node_tp(l2_node, l2_tp)
         rec, l2_node = ip_rec_by_l2_node(l2_node, l2_tp.name)
         debug_print "  - add_l3_node_tp: l2=#{l2_node.name}[#{l2_tp.name}], rec=#{rec}, l2_node=#{l2_node}"
 
-        return [nil, nil] unless rec
+        # ignore it for linked tp (L2 linked tp)
+        return [nil, nil] if linked_l2_tp?(l2_node, l2_tp) && rec.nil?
+
+        if !linked_l2_tp?(l2_node, l2_tp) && rec.nil?
+          # raise error for unlinked tp
+          raise StandardError, "Corresponding ip-owner interface is not found: #{l2_node.name}[#{l2_tp.name}]"
+        end
 
         l3_node = add_l3_node(rec, l2_node)
         l3_tp = add_l3_tp(rec, l3_node, l2_node.name, l2_tp.name)
         [l3_node, l3_tp]
       end
+      # rubocop:enable Metrics/AbcSize
 
       # @param [Netomox::PseudoDSL::PNode] l3_seg_node Layer3 segment-node (L3/src)
       # @param [Netomox::PseudoDSL::PLink] l2_link Layer2 link (l2, node -> seg_node)
@@ -367,16 +411,23 @@ module NetomoxExp
         end
       end
 
+      # @param [Netomox::PseudoDSL::PNode] l2_node Node name (L2)
+      # @param [Netomox::PseudoDSL::PTermPoint] l2_tp Term-point name (of the L2 node)
+      # @return [Boolean] true if the term-point is linked
+      def linked_l2_tp?(l2_node, l2_tp)
+        l2_link = @layer2p.find_link_by_src_name(l2_node.name, l2_tp.name)
+        !l2_link.nil?
+      end
+
       # add unlinked interface which owns ip address (interface to external network/AS)
       # @return [void]
       def add_unlinked_ip_owner_tp
-        debug_print '# add_unlinked_tp'
+        debug_print '# add_unlinked_ip_owner_tp'
         @layer2p.nodes.each do |l2_node|
           debug_print "  - target node: #{l2_node.name}"
           l2_node.tps.each do |l2_tp|
-            l2_link = @layer2p.find_link_by_src_name(l2_node.name, l2_tp.name)
             # nothing to do if the term-point is linked (L2)
-            next if l2_link
+            next if linked_l2_tp?(l2_node, l2_tp)
 
             debug_print "    find unlinked tp: #{l2_tp.name}"
             add_l3_node_tp_by_l2_node_tp(l2_node, l2_tp)

--- a/lib/topology_builder/topology_builder.rb
+++ b/lib/topology_builder/topology_builder.rb
@@ -13,6 +13,14 @@ module NetomoxExp
     # Regexp to check interface (term-point) name (loopback interface or not)
     LO_INTERFACE_REGEXP = %r{^lo(?:opback)?[-\d./:]*$}i
 
+    # juniper interface name (phy/unit)
+    #   example         JUNOS_INTERFACE_REGEXP.match(intf_str).to_a
+    #   string (=[0])   [1]          [2]
+    #   xe-0/3/0:0.0    xe-0/0/0:0   0
+    #   ge-0/10.1112    ge-0/10      1112
+    #   lo0.0           lo0          0
+    JUNOS_INTERFACE_REGEXP = %r{([\w-]+[\d+/]+(?::\d+)?)\.(\d+)}
+
     module_function
 
     # @param [Array<Netomox::PseudoDSL::PNetworks>] nws Networks

--- a/lib/topology_builder/topology_builder.rb
+++ b/lib/topology_builder/topology_builder.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'l1_data_builder'
+require_relative 'l1_l3_data_builder'
 require_relative 'l2_data_builder'
 require_relative 'l3_data_builder'
 require_relative 'expanded_l3_data_builder'
 require_relative 'ospf_data_builder'
-require_relative 'bgp_data_builder'
+require_relative 'bgp_proc_data_builder'
 
 module NetomoxExp
   # Topology data builder
@@ -40,7 +40,7 @@ module NetomoxExp
     # @return [Hash] RFC8345 topology data
     def generate_data(target, layer: 'layer1', debug: false)
       l1_debug = debug_layer?(debug, layer, 1)
-      l1_builder = L1DataBuilder.new(target:, debug: l1_debug)
+      l1_builder = L1L3DataBuilder.new(target:, debug: l1_debug)
       layer1_nws = l1_builder.make_networks
       if l1_debug
         layer1_nws.dump
@@ -93,7 +93,7 @@ module NetomoxExp
       to_data([ospf_nws, layer3_nws, layer2_nws, layer1_nws])
 
       bgp_debug = debug_layer?(debug, layer, 'bgp')
-      bgp_builder = BgpDataBuilder.new(
+      bgp_builder = BgpProcDataBuilder.new(
         target:,
         layer3p: layer3_nws.find_network_by_name('layer3'),
         debug: bgp_debug


### PR DESCRIPTION
* L1, ip-owner interface の追加処理の修正
  * 管理インタフェース(active=false)を対象外に設定
* L2−L3のトポロジデータ作成処理の修正・更新
* bgp-proc レイヤのsupport処理の修正(L3 vrf 対応)