### PR TITLE
Bgp policy dsl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :production do
   source 'https://rubygems.pkg.github.com/ool-mddo' do
-    gem 'netomox', '>= 0.9.0.pre9'
+    gem 'netomox', '>= 0.9.0.pre10'
   end
 
   gem 'grape', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :production do
   source 'https://rubygems.pkg.github.com/ool-mddo' do
-    gem 'netomox', '>= 0.9.0.pre5'
+    gem 'netomox', '>= 0.9.0.pre8'
   end
 
   gem 'grape', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :production do
   source 'https://rubygems.pkg.github.com/ool-mddo' do
-    gem 'netomox', '>= 0.8.0'
+    gem 'netomox', '>= 0.9.0.pre5'
   end
 
   gem 'grape', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :production do
   source 'https://rubygems.pkg.github.com/ool-mddo' do
-    gem 'netomox', '>= 0.9.0.pre8'
+    gem 'netomox', '>= 0.9.0.pre9'
   end
 
   gem 'grape', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :production do
   source 'https://rubygems.pkg.github.com/ool-mddo' do
-    gem 'netomox', '>= 0.9.0.pre10'
+    gem 'netomox', '>= 0.9.0'
   end
 
   gem 'grape', '>= 1.7.0'

--- a/lib/api/topologies/network/snapshot/external_as_topology.rb
+++ b/lib/api/topologies/network/snapshot/external_as_topology.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'grape'
+require 'json'
+require 'open3'
 
 module NetomoxExp
   module ApiRoute
@@ -10,26 +12,17 @@ module NetomoxExp
       resource 'external_as_topology' do
         get do
           network, snapshot = %i[network snapshot].map { |key| params[key] }
-          # NOTE: to `load` topology script, it must be absolute-path
-          #   see also: https://docs.ruby-lang.org/ja/latest/method/Kernel/m/load.html
+          # NOTE: absolute-path of external_as_script
           ext_topo_dir = File.join(CONFIGS_DIR, network, snapshot, 'external_as_topology')
-          puts "# DEBUG: ext_topo_dir=#{ext_topo_dir}"
           error!("#{network}/#{snapshot} does not have external-AS topology dir", 404) unless Dir.exist?(ext_topo_dir)
 
           ext_topo_script = File.join(ext_topo_dir, 'main.rb')
           error!("External-AS topology script is not found in #{ext_topo_dir}", 404) unless File.exist?(ext_topo_script)
 
-          # param [String] script
-          # return [String] external-AS topology data (RFC8345 json string)
-          generate_topology_proc = lambda do |script|
-            # (re)load every call
-            load script
-            # the script defines `generate_topology` function that returns RFC8345 topology json string as external-AS
-            generate_topology
-          end
-
-          # response
-          generate_topology_proc.call(ext_topo_script)
+          command = "ruby #{ext_topo_script}"
+          logger.info "Call external script: #{command}"
+          output, _status = Open3.capture2(command)
+          JSON.parse(output)
         end
       end
     end

--- a/lib/static_verification/bgp_proc_verifier.rb
+++ b/lib/static_verification/bgp_proc_verifier.rb
@@ -5,6 +5,8 @@ require_relative 'verifier_base'
 
 module NetomoxExp
   module StaticVerifier
+    # rubocop:disable Metrics/ClassLength
+
     # bgp-proc verifier
     class BgpProcVerifier < VerifierBase
       # @param [Netomox::Topology::Networks] networks Networks object
@@ -18,10 +20,93 @@ module NetomoxExp
         verify_layer(severity) do
           verify_all_links { |bgp_proc_link| verify_peer_params(bgp_proc_link) }
           verify_all_node_tps { |bgp_proc_node, bgp_proc_tp| verify_node_tp_asn(bgp_proc_node, bgp_proc_tp) }
+          verify_all_nodes { |bgp_proc_node| verify_bgp_policy_refs(bgp_proc_node) }
         end
       end
 
       private
+
+      # @param [Netomox::Topology::MddoBgpProcNodeAttribute] attribute Node attribute (bgp-proc)
+      # @param [Netomox::Topology::MddoBgpPolicyAction] action Action of a bgp-policy statement
+      # @return [nil, Netomox::Topology::SubAttributeBase] nil if not found reference
+      def find_bgp_policy_action_ref(attribute, action)
+        case action
+        when Netomox::Topology::MddoBgpPolicyActionApply
+          attribute.policies.find { |p| p.name == action.apply }
+        when Netomox::Topology::MddoBgpPolicyActionCommunity
+          attribute.community_sets.find { |c| c.name == action.community.name }
+        else
+          action
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      # @param [Netomox::Topology::MddoBgpProcNodeAttribute] attribute Node attribute (bgp-proc)
+      # @param [Netomox::Topology::MddoBgpPolicyCondition] condition Condition of a bgp-policy statement
+      # @return [nil, Array<Hash>, Netomox::Topology::SubAttributeBase] nil if not found reference
+      #   NOTE: Array<Hash>...check result of multiple conditions
+      def find_bgp_policy_condition_ref(attribute, condition)
+        case condition
+        when Netomox::Topology::MddoBgpPolicyConditionPolicy
+          attribute.policies.find { |p| p.name == condition.policy }
+        when Netomox::Topology::MddoBgpPolicyConditionAsPathGroup
+          attribute.as_path_sets.find { |a| a.group_name == condition.as_path_group }
+        when Netomox::Topology::MddoBgpPolicyConditionCommunity
+          condition.communities.map do |cond_community|
+            result = attribute.community_sets.find { |c| c.name == cond_community }
+            { result:, condition: }
+          end
+        when Netomox::Topology::MddoBgpPolicyConditionPrefixList
+          attribute.prefix_sets.find { |p| p.name == condition.prefix_list }
+        when Netomox::Topology::MddoBgpPolicyConditionPrefixListFilter
+          attribute.prefix_sets.find { |p| p.name == condition.prefix_list_filter.prefix_list }
+        else
+          condition
+        end
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
+
+      # @param [Netomox::Topology::Node] node Node (bgp-proc)
+      # @return [void]
+      def verify_bgp_policy_refs(node)
+        node.attribute.policies.each do |policy|
+          policy.default.actions.each do |action|
+            next if find_bgp_policy_action_ref(node.attribute, action)
+
+            msg = "Action reference is not found, #{action.to_data} in statement:default of policy:#{policy.name}"
+            add_log_message(:error, node.path, msg)
+          end
+          policy.statements.each do |statement|
+            msg_suffix = "in statement:#{statement.name} of policy:#{policy.name}"
+            statement.actions.each do |action|
+              next if find_bgp_policy_action_ref(node.attribute, action)
+
+              msg = "Action reference is not found, #{action.to_data} #{msg_suffix}"
+              add_log_message(:error, node.path, msg)
+            end
+            statement.conditions.each do |condition|
+              find_data = find_bgp_policy_condition_ref(node.attribute, condition)
+              if find_data.is_a?(Array)
+                find_data.each do |find_datum|
+                  next if find_datum[:result]
+
+                  msg = "Condition reference is not found, #{condition.to_data};#{find_datum[:condition]} #{msg_suffix}"
+                  add_log_message(:error, node.path, msg)
+                end
+                next
+              end
+              next if find_data
+
+              msg = "Condition reference is not found, #{condition.to_data} #{msg_suffix}"
+              add_log_message(:error, node.path, msg)
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
 
       # @param [Netomox::Topology::Node] node Node (bgp-proc)
       # @param [Netomox::Topology::TermPoint] term_point TermPoint of the node (bgp-proc)
@@ -81,5 +166,6 @@ module NetomoxExp
         verify_timer(link.path, src_tp, dst_tp)
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end


### PR DESCRIPTION
* netomox 0.9.0
  * Add bgp-policy DSL
* Updated the API for executing external AS topology scripts to execute scripts on each API call, eliminating the need to reload the process (container) when updating scripts.
* Add a static verification API to check bgp-policy reference existence.