### PR TITLE
V1.8.0 clab topo

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,15 @@ curl -s http://localhost:9292/topologies/mddo-ospf/emulated_asis/topology/layer3
 Convert specified layer topology to clab-topo.yaml for container-lab
 
 * GET `/topologies/<network>/<snapshot>/topology/<layer>/containerlab_topology`
-  * NOTE: It returns json data. Convert it to yaml using other tool
-  * option
-    * env_name: containerlab environment name (default: "emulated")
-    * bind_license: docker volume mount format string to bind license file into a container
-    * license: file path of license file
-
+  * NOTE: This API returns json data. Convert it to yaml for containerlab.
+  * option for containerlab
+    * `env_name`: containerlab environment name (default: "emulated")
+  * options for router node (cRPD)
+    * `image`: image name
+    * [optional] `bind_license`: docker volume mount string to bind license file into a container
+    * [optional] `license`: file path of license file
 ```shell
-curl -s "http://localhost:9292/topologies/mddo-ospf/emulated_asis/topology/layer3/containerlab_topology?bind_license=license.key:/tmp/license.key:ro" \
+curl -s "http://localhost:9292/topologies/mddo-ospf/emulated_asis/topology/layer3/containerlab_topology?image=crpd:22.1R1.10&bind_license=license.key:/tmp/license.key:ro" \
   | ruby -r json -r yaml -e "puts YAML.dump_stream(JSON.parse(STDIN.read))"
 ```
 

--- a/lib/api/topologies/network/snapshot/topology/layer/convert_layer_topology.rb
+++ b/lib/api/topologies/network/snapshot/topology/layer/convert_layer_topology.rb
@@ -22,16 +22,17 @@ module NetomoxExp
       desc 'convert layer data to container-lab topology json'
       params do
         optional :env_name, type: String, desc: 'Environment name (for container-lab)', default: 'emulated'
-        optional :bind_license, type: String, desc: 'Bind configs (like "license.key:/tmp/license.key")'
-        optional :license, type: String, desc: 'License file path for container'
+        optional :bind_license, type: String, desc: 'Router bind configs (like "license.key:/tmp/license.key")'
+        optional :license, type: String, desc: 'Router license file path for container'
+        requires :image, type: String, desc: 'Router image name'
       end
       get 'containerlab_topology' do
         network, snapshot, layer = %i[network snapshot layer].map { |key| params[key] }
 
         topology_data = read_topology_file(network, snapshot)
         ns_converter = ns_converter_wo_topology(network)
-        opts = %i[env_name bind_license license].select { |key| params.key?(key) }
-                                                .to_h { |key| [key, params[key]] }
+        opts = %i[env_name bind_license license image].select { |key| params.key?(key) }
+                                                      .to_h { |key| [key, params[key]] }
         clab_converter = ContainerLabConverter.new(topology_data, layer, ns_converter, opts)
 
         # response

--- a/lib/convert_namespace/namespace_convert_table/term_point_name_table.rb
+++ b/lib/convert_namespace/namespace_convert_table/term_point_name_table.rb
@@ -177,8 +177,8 @@ module NetomoxExp
       # @return [Hash] Converted term-point (loopback) name
       def forward_convert_actual_lo_name(src_tp_name)
         # pick last number e.g. loX.Y -> Y
-        index = src_tp_name.match(/(\d+)/)[-1]
-        emulated_name_dict("lo.#{index}") # cRPD loopback
+        index = src_tp_name.match(/(\d+)$/)[-1]
+        emulated_name_dict("lo0.#{index}") # cRPD loopback
       end
 
       # @param [Integer] index Term-point index

--- a/lib/convert_topology/containerlab_converter.rb
+++ b/lib/convert_topology/containerlab_converter.rb
@@ -72,7 +72,7 @@ module NetomoxExp
       when 'segment'
         define_node_data('ovs-bridge')
       when 'node'
-        opts = { image: 'crpd:22.1R1.10', config: "#{node_name}.conf" }
+        opts = { image: @options[:image], config: "#{node_name}.conf" }
         opts[:bind_configs] = [@options[:bind_license]] if @options.key?(:bind_license)
         opts[:license] = @options[:license] if @options.key?(:license)
         define_node_data('juniper_crpd', **opts)


### PR DESCRIPTION
cRPD更新のための修正
* clab-topo.yaml の crpd image をREST APIオプションで指定できるように変更
* loopback interface の名前が変わっていたので修正 (`lo.0` → `lo0.0`)